### PR TITLE
Fix levels for examples

### DIFF
--- a/.enb/bundle-node-configurator.js
+++ b/.enb/bundle-node-configurator.js
@@ -9,8 +9,12 @@ var platform = 'desktop'; // FIXME: !
 module.exports = function(config, nodes, levels) {
     config.nodes(nodes, function(nodeConfig) {
         var nodeDir = nodeConfig.getNodePath(),
-            blockSublevelDir = path.join(nodeDir, '..', '.blocks'),
-            sublevelDir = path.join(nodeDir, 'blocks'),
+            blockName = path.basename(path.dirname(nodeDir)),
+            blockSublevelDir = path.join(nodeDir, blockName + '.blocks'),
+
+            exampleName = path.basename(nodeDir),
+            sublevelDir = path.join(nodeDir, exampleName + '.blocks'),
+
             extendedLevels = [].concat(levels); // TODO: check if it's proper levels
 
         if(fs.existsSync(blockSublevelDir)) {


### PR DESCRIPTION
В enb-bem-examples начиная с 1.0.0 изменилась сборка уровней для примеров (см. https://github.com/enb/enb-bem-examples/blob/master/CHANGELOG.md#Сборка-уровней-для-примеров).
