### PR TITLE
Add 'force' option to 'del'

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function(pathToLib, version) {
             return new Promise(function(resolve, reject) {
                 var destPath = path.resolve(initialCwd, config.outputFolder || 'output', 'data', lib);
 
-                del(destPath).then(function() {
+                del(destPath, { force: true }).then(function() {
                     mv(path.resolve(config.tempFolder || 'tmp', 'data', lib), destPath, { mkdirp: true }, function(err) {
                         if (err) return reject(err);
 


### PR DESCRIPTION
Add 'force' option to 'del' in order to suppress error:

Cannot delete files/folders outside the current working directory. Can be overriden with the 'force' option.
